### PR TITLE
Improve ChatsScreen to show matches

### DIFF
--- a/src/components/ChatListItem/index.js
+++ b/src/components/ChatListItem/index.js
@@ -8,12 +8,11 @@ import strings from 'localization';
 import styles from './styles';
 
 const ChatListItem = ({ match, onPress }) => {
-  /* eslint-disable camelcase */
-  const { match_id, user, last_message, topic_icon } = match;
-  const uri = user?.avatar?.original_url;
+  const { matchId, user, lastMessage, topicIcon } = match;
+  const uri = user?.avatar?.originalUrl;
 
   return (
-    <TouchableHighlight key={`match-${match_id}`} underlayColor={WHITE} onPress={onPress}>
+    <TouchableHighlight key={`match-${matchId}`} underlayColor={WHITE} onPress={onPress}>
       <View style={styles.container}>
         <Image
           source={
@@ -28,13 +27,13 @@ const ChatListItem = ({ match, onPress }) => {
 
         <View>
           <Text style={styles.title}>
-            {user?.full_name || strings.CHATS_SCREEN.notAvailableName}
+            {user?.fullName || strings.CHATS_SCREEN.notAvailableName}
           </Text>
-          {!!last_message && <Text style={styles.subtitle}>{last_message}</Text>}
+          {!!lastMessage && <Text style={styles.subtitle}>{lastMessage}</Text>}
         </View>
 
         <View style={styles.containerIconRight}>
-          <Image source={{ uri: topic_icon }} style={styles.iconRight} />
+          <Image source={{ uri: topicIcon }} style={styles.iconRight} />
         </View>
       </View>
     </TouchableHighlight>

--- a/src/components/ChatListItem/index.js
+++ b/src/components/ChatListItem/index.js
@@ -2,8 +2,9 @@ import React from 'react';
 import { TouchableHighlight, View, Text, Image } from 'react-native';
 import { WHITE } from 'constants/colors';
 import { PROFILE_ICON } from 'constants/icons';
+import { MATCH } from 'constants/propTypes';
+import { func } from 'prop-types';
 import strings from 'localization';
-import { object, func } from 'prop-types';
 import styles from './styles';
 
 const ChatListItem = ({ match, onPress }) => {
@@ -41,7 +42,7 @@ const ChatListItem = ({ match, onPress }) => {
 };
 
 ChatListItem.propTypes = {
-  match: object.isRequired,
+  match: MATCH.isRequired,
   onPress: func.isRequired,
 };
 

--- a/src/components/ChatListItem/index.js
+++ b/src/components/ChatListItem/index.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { TouchableHighlight, View, Text, Image } from 'react-native';
+import { WHITE } from 'constants/colors';
+import { PROFILE_ICON } from 'constants/icons';
+import strings from 'localization';
+import { object, func } from 'prop-types';
+import styles from './styles';
+
+const ChatListItem = ({ match, onPress }) => {
+  /* eslint-disable camelcase */
+  const { match_id, user, last_message, topic_icon } = match;
+  const uri = user?.avatar?.original_url;
+
+  return (
+    <TouchableHighlight key={`match-${match_id}`} underlayColor={WHITE} onPress={onPress}>
+      <View style={styles.container}>
+        <Image
+          source={
+            uri
+              ? {
+                  uri,
+                }
+              : PROFILE_ICON()
+          }
+          style={styles.iconLeft}
+        />
+
+        <View>
+          <Text style={styles.title}>
+            {user?.full_name || strings.CHATS_SCREEN.notAvailableName}
+          </Text>
+          {!!last_message && <Text style={styles.subtitle}>{last_message}</Text>}
+        </View>
+
+        <View style={styles.containerIconRight}>
+          <Image source={{ uri: topic_icon }} style={styles.iconRight} />
+        </View>
+      </View>
+    </TouchableHighlight>
+  );
+};
+
+ChatListItem.propTypes = {
+  match: object.isRequired,
+  onPress: func.isRequired,
+};
+
+export default ChatListItem;

--- a/src/components/ChatListItem/styles.js
+++ b/src/components/ChatListItem/styles.js
@@ -1,0 +1,38 @@
+import { StyleSheet } from 'react-native';
+import { PRIMARY_FONT_REGULAR, PRIMARY_FONT_SEMI_BOLD } from 'constants/fonts';
+import { BLACK } from 'constants/colors';
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    height: 60,
+    borderTopColor: BLACK,
+    borderTopWidth: 0.5,
+  },
+  title: {
+    color: BLACK,
+    fontFamily: PRIMARY_FONT_SEMI_BOLD,
+  },
+  subtitle: {
+    color: BLACK,
+    fontFamily: PRIMARY_FONT_REGULAR,
+  },
+  iconLeft: {
+    width: 40,
+    height: 40,
+    left: 20,
+    marginRight: 40,
+    borderRadius: 50,
+  },
+  containerIconRight: {
+    position: 'absolute',
+    right: 20,
+  },
+  iconRight: {
+    width: 25,
+    height: 25,
+  },
+});
+
+export default styles;

--- a/src/constants/propTypes.js
+++ b/src/constants/propTypes.js
@@ -1,0 +1,21 @@
+import { shape, number, string } from 'prop-types';
+
+const AVATAR = shape({
+  originalUrl: string,
+  normalUrl: string,
+  smallThumb_url: string,
+});
+
+const USER = shape({
+  id: number.isRequired,
+  fullNname: string,
+  avatar: AVATAR.isRequired,
+});
+
+export const MATCH = shape({
+  matchId: number.isRequired,
+  topicIcon: string.isRequired,
+  lastMessage: string,
+  unreadMessages: number,
+  user: USER.isRequired,
+});

--- a/src/constants/propTypes.js
+++ b/src/constants/propTypes.js
@@ -3,12 +3,12 @@ import { shape, number, string } from 'prop-types';
 const AVATAR = shape({
   originalUrl: string,
   normalUrl: string,
-  smallThumb_url: string,
+  smallThumbUrl: string,
 });
 
 const USER = shape({
   id: number.isRequired,
-  fullNname: string,
+  fullName: string,
   avatar: AVATAR.isRequired,
 });
 

--- a/src/localization/en.js
+++ b/src/localization/en.js
@@ -71,5 +71,6 @@ export default {
 
   CHATS_SCREEN: {
     title: 'Chat',
+    notAvailableName: 'Name not available',
   },
 };

--- a/src/localization/es.js
+++ b/src/localization/es.js
@@ -72,5 +72,6 @@ export default {
 
   CHATS_SCREEN: {
     title: 'Chat',
+    notAvailableName: 'Nombre no disponible',
   },
 };

--- a/src/screens/ChatsScreen/index.js
+++ b/src/screens/ChatsScreen/index.js
@@ -1,11 +1,12 @@
 import React from 'react';
-import { View } from 'react-native';
+import { View, FlatList } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
-
 import Container from 'components/common/Container';
+import ChatListItem from 'components/ChatListItem';
 import strings from 'localization';
 import { LOCATION_ICON, PROFILE_ICON } from 'constants/icons';
 import { CHATS_SCREEN, MAIN_SCREEN, PROFILE_SCREEN } from 'constants/screens';
+import styles from './styles';
 
 const ChatsScreen = () => {
   const navigation = useNavigation();
@@ -19,7 +20,15 @@ const ChatsScreen = () => {
         onPressIconLeft: () => navigation.navigate(PROFILE_SCREEN),
         onPressIconRight: () => navigation.navigate(MAIN_SCREEN),
       }}>
-      <View testID={CHATS_SCREEN}></View>
+      <View testID={CHATS_SCREEN}>
+        <FlatList
+          // TO DO: Add logic to get matches and pass as 'data'
+          data={[]}
+          contentContainerStyle={styles.flatListContainer}
+          // TO DO: Add function to open chat onPress
+          renderItem={({ item: match }) => <ChatListItem match={match} onPress={() => {}} />}
+        />
+      </View>
     </Container>
   );
 };

--- a/src/screens/ChatsScreen/styles.js
+++ b/src/screens/ChatsScreen/styles.js
@@ -1,0 +1,11 @@
+import { StyleSheet } from 'react-native';
+import { BLACK } from 'constants/colors';
+
+const styles = StyleSheet.create({
+  flatListContainer: {
+    borderBottomColor: BLACK,
+    borderBottomWidth: 0.5,
+  },
+});
+
+export default styles;


### PR DESCRIPTION
## Show matches and chats

The idea of this PR is just to create the list and components to show matches with the correct styles and component. It's not fetching the data from API. The next step is to add the logic to get matches and show them in this list. 

---

#### Description:

* Improve ChatsScreen adding list to show matchets
* Create ChatListItem to render each item in the list. 
* Add Translations 

---

#### Trello: https://trello.com/c/29WO1jQA

---

#### Figma:

<img src="https://user-images.githubusercontent.com/40902023/168641282-57ab31e7-6fa7-472e-b67c-dbb36e479851.png"  width="300"/> 

---

#### Screenshot: 
 
* IOS (iPhone 13):
<img src="https://user-images.githubusercontent.com/40902023/168642015-609eb5b2-474c-4d72-b250-4147ef8b4f3b.png"  width="300"/> 






















